### PR TITLE
Create /insights folder on runner and make it writeable

### DIFF
--- a/apicast-slave/Dockerfile
+++ b/apicast-slave/Dockerfile
@@ -13,7 +13,10 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
     yum clean all && \
     mkdir -p /var/lib/jenkins && \
     chown -R 1001:0 /var/lib/jenkins && \
-    chmod -R g+w /var/lib/jenkins
+    chmod -R g+w /var/lib/jenkins && \
+    mkdir -p /insights && \
+    chmod 777 /insights && \
+    chown 1001:0 /insights
 
 # Copy the entrypoint
 COPY configuration/* /var/lib/jenkins/


### PR DESCRIPTION
3scale builds have been failing due to insufficient permissions to create folders and write files under /insights. This update works around the problem by ensuring that the folder exists and is world-writeable. If there's a better solution, I'm all ears!