### PR TITLE
Update python3 dockerfile for latest rhel7

### DIFF
--- a/slave3/Dockerfile
+++ b/slave3/Dockerfile
@@ -15,15 +15,13 @@ RUN yum-config-manager --disable rhel* 1>/dev/null && \
     yum clean all && \
     export INSTALL_PKGS="nss_wrapper java-1.8.0-openjdk-headless \
         java-1.8.0-openjdk-devel nss_wrapper gettext tar git curl gcc \
-        unzip file python36 python36-devel pandoc wget python3-pyOpenSSL PyYAML pyOpenSSL" && \
+        unzip file python3 python3-devel pandoc wget python3-pyOpenSSL PyYAML pyOpenSSL" && \
     yum install -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /var/lib/jenkins && \
     chown -R 1001:0 /var/lib/jenkins && \
     chmod -R g+w /var/lib/jenkins && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    /bin/python36 get-pip.py && \
-    /bin/python36 -m pip install -r requirements.txt 
+    /bin/python3 -m pip install -r requirements.txt 
 
 # Copy the entrypoint
 COPY configuration/* /var/lib/jenkins/

--- a/slave3/requirements.txt
+++ b/slave3/requirements.txt
@@ -1,3 +1,4 @@
+cryptography>=3.2,<=3.3.2
 virtualenv
 flake8==3.3.0
 coverage==4.3.4


### PR DESCRIPTION
* Updated dockerfile to use python3 and pip3 included in RHEL7.7 and
later
* Updated requirements.txt to fix issue with pip 9 and cryptography
module

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>