### PR TITLE
Update image to work with current RHEL7

### DIFF
--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -19,7 +19,7 @@ RUN yum-config-manager --disable rhel* 1>/dev/null && \
     mkdir -p /var/lib/jenkins && \
     chown -R 1001:0 /var/lib/jenkins && \
     chmod -R g+w /var/lib/jenkins && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && \
     python get-pip.py && \
     pip install -r requirements.txt
 

--- a/slave/requirements.txt
+++ b/slave/requirements.txt
@@ -3,15 +3,10 @@ coverage==4.3.4
 pytest==3.0.6
 pyyaml>=3.10,<=3.12
 pytest-cov==2.4.0
-Sphinx
-nbsphinx==0.3.1
 pyOpenSSL
 importlib
-Jinja2==2.9.6
-sphinx_rtd_theme
 futures==3.0.5
 wheel
 six
-ipython<6
 virtualenv
 setuptools>=18.5


### PR DESCRIPTION
* Change location for pip bootstrap
* Remove documentation build software since we now only build on Python3

Signed-off-by: Bob Fahr <20520336+bfahr@users.noreply.github.com>